### PR TITLE
Expose `Field<Type>::get_attrs,get_type`

### DIFF
--- a/src/field.rs
+++ b/src/field.rs
@@ -66,6 +66,10 @@ impl Field<Type> {
     pub fn get_name(&self) -> String {
         self.accessor.to_string()
     }
+
+    pub fn get_attrs(&self) -> &[Attribute] {
+        &self.attrs
+    }
 }
 
 impl Field<Value> {

--- a/src/field.rs
+++ b/src/field.rs
@@ -77,3 +77,9 @@ impl Field<Value> {
         self.element
     }
 }
+
+impl Field<Type> {
+    pub fn get_type(&self) -> &Type {
+        &self.element
+    }
+}


### PR DESCRIPTION
I can't find any reason to make the `get_attrs` method only available on `Field<Value>` but not `Field<Type>`.

It's very useful when we try to derive a method without self receiver, e.g.:

```rust
            mod schema {
                type Field;
                type VecField;

                trait Fields {
                    fn fields() -> VecField;
                }
            }
```

It is very likely that it was simply forgotten by #22.

@eupn Can you give some suggestions? Thanks!